### PR TITLE
Clean up http.rkt

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -186,24 +186,16 @@
         body:expr ...
         run-args:kwarg-pair ...)
      (quasisyntax/loc stx
-       (define (name client . params)
-         body ...
-         #,((datum process-expr.wrap)
-            #`(run-route (make-route method 'method path ...)
-                         (client-http-client client)
-                         (~@ run-args.kw run-args.arg) ...))))]))
+       (begin
+         (provide name)
+         (define (name client . params)
+           body ...
+           #,((datum process-expr.wrap)
+              #`(run-route (make-route method 'method path ...)
+                           (client-http-client client)
+                           (~@ run-args.kw run-args.arg) ...)))))]))
 
 ;; CHANNEL ENDPOINTS
-
-(provide get-channel modify-channel delete-channel
-         get-channel-messages get-channel-message
-         create-message edit-message delete-message bulk-delete-messages
-         create-reaction delete-own-reaction delete-user-reaction get-reactions delete-all-reactions
-         edit-channel-permissions delete-channel-permission
-         get-channel-invites create-channel-invite
-         trigger-typing-indicator
-         get-pinned-messages add-pinned-channel-message delete-pinned-channel-message
-         group-dm-add-recipient group-dm-remove-recipient)
 
 (define/endpoint (get-channel _client channel-id)
   (get "channels" channel-id))
@@ -330,9 +322,6 @@
 
 ;; EMOJI ENDPOINTS
 
-(provide list-guild-emoji get-guild-emoji create-guild-emoji
-         modify-guild-emoji delete-guild-emoji)
-
 (define/endpoint (list-guild-emoji _client guild-id)
   (get "guilds" guild-id "emojis"))
 
@@ -356,18 +345,6 @@
   (delete "guilds" guild-id "emojis" emoji-id))
 
 ;; GUILD ENDPOINTS
-
-(provide get-guild modify-guild delete-guild
-         get-guild-channels create-guild-channel modify-guild-channel-permissions
-         get-guild-member list-guild-members add-guild-member modify-guild-member remove-guild-member
-         modify-user-nick
-         add-guild-member-role remove-guild-member-role
-         get-guild-bans create-guild-ban remove-guild-ban
-         get-guild-roles create-guild-role modify-guild-role modify-guild-role-positions delete-guild-role
-         get-guild-prune-count begin-guild-prune
-         get-guild-invites
-         get-guild-integrations create-guild-integration modify-guild-integration delete-guild-integrations sync-guild-integrations
-         get-guild-embed modify-guild-embed)
 
 (define/endpoint (get-guild _client guild-id)
   (get "guilds" guild-id))
@@ -487,10 +464,6 @@
 
 ;; USER ENDPOINTS
 
-(provide get-current-user get-user modify-current-user
-         get-current-user-guilds leave-guild
-         get-user-dms create-dm create-group-dm)
-
 (define/endpoint (get-current-user _client)
   (get "users" "@me"))
 
@@ -531,12 +504,6 @@
   #:data (json-payload data))
 
 ;; WEBHOOK ENDPOINTS
-(provide create-webhook
-         get-channel-webhooks get-guild-webhooks
-         get-webhook get-webhook-with-token
-         modify-webhook modify-webhook-with-token
-         delete-webhook delete-webhook-with-token
-         execute-webhook)
 
 (define/endpoint (create-webhook _client channel-id name avatar avatar-type)
   (post "channels" channel-id "webhooks")

--- a/info.rkt
+++ b/info.rkt
@@ -4,8 +4,7 @@
                "http-easy"
                "rfc6455"
                "rackunit-lib"
-               "scribble-lib"
-               "srfi-lite-lib"))
+               "scribble-lib"))
 (define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/racket-cord.scrbl" ())))
 (define pkg-desc "A racket wrapper for the discord API.")

--- a/private/events.rkt
+++ b/private/events.rkt
@@ -2,7 +2,8 @@
 
 (require (only-in racket/function thunk)
          (only-in racket/hash hash-union)
-         (only-in racket/string string-replace)
+         (only-in racket/string string-replace string-trim)
+         (only-in racket/exn exn->string)
          "data.rkt"
          "logger.rkt")
 
@@ -16,7 +17,8 @@
     (log-discord-debug "DISPATCHING EVENT: ~a" type)
     (with-handlers ([exn:fail?
                      (lambda (v)
-                       (log-discord-warning "Event ~a ERRORED with: ~a" type v))])
+                       (log-discord-warning "Event ~a ERRORED with: ~a"
+                                            type (string-trim (exn->string v))))])
       (let ([client (ws-client-client ws-client)]
             [events (client-events (ws-client-client ws-client))]
             [raw-evt (string->symbol (string-downcase (format "raw-~a" (string-replace type "_" "-"))))])


### PR DESCRIPTION
This PR:
- Refactors all of the endpoint declarations in `http.rkt` to use a new macro that was made for it.
- Rewrites previously buggy ratelimiting code so it is hopefully less buggy.
- Makes exceptions caught from dispatched events be properly logged.

Endpoint declarations are much more concise and meaningful now, with less boilerplate.
Overall, this means that `gzip -9` can now only compress `http.rkt` by 79.8%, down from 85.4%.

Ratelimitng code no longer depends on weird timezone things which weren't working. Events are used instead of locks for keeping track of time.