### PR TITLE
Use correct HTTP method for create-reaction endpoint

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -262,7 +262,7 @@
   (delete "channels" channel-id "messages" message-id))
 
 (define/endpoint (create-reaction _client channel-id message-id emoji)
-  (post "channels" channel-id "messages" message-id "reactions" emoji "@me"))
+  (put "channels" channel-id "messages" message-id "reactions" emoji "@me"))
 
 (define/endpoint (delete-own-reaction _client channel-id message-id emoji)
   (delete "channels" channel-id "messages" message-id "reactions" emoji "@me"))


### PR DESCRIPTION
As per the documentation here: https://discord.com/developers/docs/resources/message#create-reaction

With POST, I got "405 Method Not Allowed". With PUT, it works :slightly_smiling_face: 

Maybe POST used to work at some point in the past?