### PR TITLE
create-message endpoint: fix reply

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -227,7 +227,13 @@
                   #:file [attachment #f])
   (post "channels" channel-id "messages")
   (define data (make-hash))
-  (when reference (hash-set! data 'message_reference reference))
+  (when reference
+    (hash-set!
+     data
+     'message_reference
+     (hasheq
+      'type 0 ; DEFAULT message reference type, used for replies
+      'message_id reference)))
   (when mentions (hash-set! data 'allowed_mentions mentions))
   (unless (null? components) (hash-set! data 'components components))
   (unless (null? sticker-ids) (hash-set! data 'sticker_ids sticker-ids))


### PR DESCRIPTION
The `message_reference` field now requires a "Message Reference Structure": https://discord.com/developers/docs/resources/message#message-reference-structure

With the old code, I get:
```text
[warning] discord: Event MESSAGE_CREATE ERRORED with: Discord gave us an error: #"{\"message\": \"Invalid Form Body\", \"code\": 50035, \"errors\": {\"message_reference\": {\"_errors\": [{\"code\": \"MODEL_TYPE_CONVERT\", \"message\": \"Expected an object/dictionary.\"}]}}}"
```