### PR TITLE
edit-message endpoint: fixed, and added support for multiple embeds

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -260,9 +260,22 @@
                                channel-id
                                message-id
                                #:content [content null]
-                               #:embed [embed null])
+                               #:embed [single-embed null]
+                               #:embeds [embeds #f])
   (patch "channels" channel-id "messages" message-id)
-  #:params (filter-null `((content . ,content) (embed . ,embed))))
+  (define data (make-hash))
+  (cond
+    [embeds
+     (define all-embeds
+       (if (null? single-embed)
+           embeds
+           (cons single-embed embeds)))
+     (hash-set! data 'embeds all-embeds)]
+    [(not (null? single-embed))
+     (hash-set! data 'embeds (list single-embed))])
+  (unless (null? content)
+    (hash-set! data 'content content))
+  #:data (json-payload data))
 
 (define/endpoint (delete-message _client channel-id message-id)
   (delete "channels" channel-id "messages" message-id))


### PR DESCRIPTION
Before this patch, Discord would complain when `edit-message` was called with `#:content`: `Discord gave us an error: #"{\"message\": \"The request body contains invalid JSON.\", \"code\": 50109}"`

I think maybe it's because it would set the `Content-Type: application/json` header but didn't include a request body, instead using a query parameter. Also, using the `#:embed` argument didn't work because this parameter must be sent in the request body, not as a query parameter.

With this patch, the edits are always sent in the request body. I also added backwards-compatible support for multiple embeds.

If the logic looks a little complicated, note that `edit-message` works a bit differently from `create-message` - omitting the `embeds` key in the request body is not the same as making it an empty list. Omitting it will leave any embeds as-is, while sending an empty list will remove any existing embeds. It's a similar story for the `content` key.